### PR TITLE
feat(gatewayapi): capture WAF (Coraza) audit log from the gateway proxy (EV-6650)

### DIFF
--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -1036,6 +1036,12 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 						Name:  "ENVOY_ACCESS_LOG_PATH",
 						Value: "/access_logs/access.log",
 					},
+					// WAF audit capture: file the collector tails for the wasm filter's
+					// Coraza "AuditLog:" lines (Envoy's app log, redirected via --log-path).
+					{
+						Name:  "WAF_AUDIT_LOG_PATH",
+						Value: wafAuditLogPath,
+					},
 					// Owning Gateway info from pod labels (set by EnvoyProxy)
 					OwningGatewayNameEnvVar,
 					OwningGatewayNamespaceEnvVar,
@@ -1049,6 +1055,10 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 					{
 						Name:      "felix-sync",
 						MountPath: "/var/run/felix",
+					},
+					{
+						Name:      "var-log-calico",
+						MountPath: "/var/log/calico",
 					},
 				},
 				SecurityContext: securitycontext.NewRootContext(true),

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -108,6 +108,13 @@ const (
 	EnvoyGatewayDeploymentContainerName = "envoy-gateway"
 	EnvoyGatewayJobContainerName        = "envoy-gateway-certgen"
 	wafFilterName                       = "waf-http-filter"
+
+	// wafLogComponentWasm is the Envoy "wasm" logger component. Envoy Gateway does not
+	// define a const for it (its enum omits wasm), but EnvoyProxy.Spec.Logging.Level
+	// passes arbitrary component keys through to Envoy's --component-log-level arg, and
+	// Envoy recognises "wasm". Setting it to info surfaces the Coraza WASM filter's
+	// "AuditLog:" lines (emitted via proxywasm.LogInfo) in Envoy's application log.
+	wafLogComponentWasm = envoyapi.ProxyLogComponent("wasm")
 )
 
 var (
@@ -952,6 +959,19 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 		// The WAF HTTP filter is not supported when the envoy proxy is deployed as a DaemonSet
 		// as there is no support for init containers in a DaemonSet.
 		if envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment != nil {
+			// Tune Envoy log levels for WAF audit capture: the wasm component logs at
+			// info so the Coraza filter's "AuditLog:" lines reach Envoy's application
+			// log, while the default stays at warn to keep the redirected log file
+			// approximately just the audit lines. A user-supplied default level (e.g.
+			// for debugging) is preserved.
+			if envoyProxy.Spec.Logging.Level == nil {
+				envoyProxy.Spec.Logging.Level = map[envoyapi.ProxyLogComponent]envoyapi.LogLevel{}
+			}
+			if _, ok := envoyProxy.Spec.Logging.Level[envoyapi.LogComponentDefault]; !ok {
+				envoyProxy.Spec.Logging.Level[envoyapi.LogComponentDefault] = envoyapi.LogLevelWarn
+			}
+			envoyProxy.Spec.Logging.Level[wafLogComponentWasm] = envoyapi.LogLevelInfo
+
 			// Add or update the Init Container to the deployment
 			wafHTTPFilter := corev1.Container{
 				Name:    wafFilterName,

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 
@@ -115,6 +116,11 @@ const (
 	// Envoy recognises "wasm". Setting it to info surfaces the Coraza WASM filter's
 	// "AuditLog:" lines (emitted via proxywasm.LogInfo) in Envoy's application log.
 	wafLogComponentWasm = envoyapi.ProxyLogComponent("wasm")
+
+	// wafAuditLogPath is the file (on the var-log-calico HostPath volume) that Envoy's
+	// application log is redirected to via --log-path, and that the l7-log-collector
+	// tails for Coraza "AuditLog:" lines (WAF_AUDIT_LOG_PATH).
+	wafAuditLogPath = "/var/log/calico/gateway/envoy.log"
 )
 
 var (
@@ -971,6 +977,17 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 				envoyProxy.Spec.Logging.Level[envoyapi.LogComponentDefault] = envoyapi.LogLevelWarn
 			}
 			envoyProxy.Spec.Logging.Level[wafLogComponentWasm] = envoyapi.LogLevelInfo
+
+			// Redirect Envoy's application log (where the wasm filter's "AuditLog:" lines
+			// land) to a file on the var-log-calico HostPath volume so the
+			// l7-log-collector can tail it. EnvoyProxy has no native log-path field, and a
+			// Patch on the envoy container's args would replace Envoy Gateway's generated
+			// args, so use ExtraArgs, which EG appends to the proxy command line. func-e
+			// parses each element as a single token, so the flag and value are separate
+			// elements. A user-supplied --log-path is left untouched.
+			if !slices.Contains(envoyProxy.Spec.ExtraArgs, "--log-path") {
+				envoyProxy.Spec.ExtraArgs = append(envoyProxy.Spec.ExtraArgs, "--log-path", wafAuditLogPath)
+			}
 
 			// Add or update the Init Container to the deployment
 			wafHTTPFilter := corev1.Container{

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -117,10 +117,14 @@ const (
 	// "AuditLog:" lines (emitted via proxywasm.LogInfo) in Envoy's application log.
 	wafLogComponentWasm = envoyapi.ProxyLogComponent("wasm")
 
-	// wafAuditLogPath is the file (on the var-log-calico HostPath volume) that Envoy's
-	// application log is redirected to via --log-path, and that the l7-log-collector
-	// tails for Coraza "AuditLog:" lines (WAF_AUDIT_LOG_PATH).
-	wafAuditLogPath = "/var/log/calico/gateway/envoy.log"
+	// wafAuditLogPath is the file that Envoy's application log is redirected to via
+	// --log-path, and that the l7-log-collector tails for Coraza "AuditLog:" lines
+	// (WAF_AUDIT_LOG_PATH). It lives on the "access-logs" emptyDir that is already
+	// mounted in both the envoy container (which writes it) and the l7-log-collector
+	// (which reads it) - so no extra volume or mount is needed. Envoy will not create
+	// parent directories for --log-path, so this is a file directly under the existing
+	// /access_logs mount, not a new subdirectory.
+	wafAuditLogPath = "/access_logs/envoy.log"
 )
 
 var (
@@ -979,12 +983,12 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 			envoyProxy.Spec.Logging.Level[wafLogComponentWasm] = envoyapi.LogLevelInfo
 
 			// Redirect Envoy's application log (where the wasm filter's "AuditLog:" lines
-			// land) to a file on the var-log-calico HostPath volume so the
-			// l7-log-collector can tail it. EnvoyProxy has no native log-path field, and a
-			// Patch on the envoy container's args would replace Envoy Gateway's generated
-			// args, so use ExtraArgs, which EG appends to the proxy command line. func-e
-			// parses each element as a single token, so the flag and value are separate
-			// elements. A user-supplied --log-path is left untouched.
+			// land) to a file on the "access-logs" emptyDir so the l7-log-collector can
+			// tail it (the collector already mounts that volume). EnvoyProxy has no native
+			// log-path field, and a Patch on the envoy container's args would replace Envoy
+			// Gateway's generated args, so use ExtraArgs, which EG appends to the proxy
+			// command line. func-e parses each element as a single token, so the flag and
+			// value are separate elements. A user-supplied --log-path is left untouched.
 			if !slices.Contains(envoyProxy.Spec.ExtraArgs, "--log-path") {
 				envoyProxy.Spec.ExtraArgs = append(envoyProxy.Spec.ExtraArgs, "--log-path", wafAuditLogPath)
 			}
@@ -1055,10 +1059,6 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 					{
 						Name:      "felix-sync",
 						MountPath: "/var/run/felix",
-					},
-					{
-						Name:      "var-log-calico",
-						MountPath: "/var/log/calico",
 					},
 				},
 				SecurityContext: securitycontext.NewRootContext(true),

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1105,7 +1105,7 @@ value:
 
 		Expect(envoyDeployment.InitContainers[1].Name).To(Equal("l7-log-collector"))
 		Expect(*envoyDeployment.InitContainers[1].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
-		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(HaveLen(2))
+		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(HaveLen(3))
 		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(ContainElements([]corev1.VolumeMount{
 			{
 				Name:      "access-logs",
@@ -1115,6 +1115,15 @@ value:
 				Name:      "felix-sync",
 				MountPath: "/var/run/felix",
 			},
+			{
+				Name:      "var-log-calico",
+				MountPath: "/var/log/calico",
+			},
+		}))
+		// WAF audit capture: the l7-log-collector tails the redirected Envoy app log.
+		Expect(envoyDeployment.InitContainers[1].Env).To(ContainElement(corev1.EnvVar{
+			Name:  "WAF_AUDIT_LOG_PATH",
+			Value: "/var/log/calico/gateway/envoy.log",
 		}))
 
 		// logger gateway name and namespace are set from the k8s downward api pod metadata.
@@ -1252,7 +1261,7 @@ value:
 
 		Expect(envoyDeployment.InitContainers[2].Name).To(Equal("l7-log-collector"))
 		Expect(*envoyDeployment.InitContainers[2].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
-		Expect(envoyDeployment.InitContainers[2].VolumeMounts).To(HaveLen(2))
+		Expect(envoyDeployment.InitContainers[2].VolumeMounts).To(HaveLen(3))
 		Expect(envoyDeployment.InitContainers[2].VolumeMounts).To(ContainElements([]corev1.VolumeMount{
 			{
 				Name:      "access-logs",
@@ -1262,6 +1271,14 @@ value:
 				Name:      "felix-sync",
 				MountPath: "/var/run/felix",
 			},
+			{
+				Name:      "var-log-calico",
+				MountPath: "/var/log/calico",
+			},
+		}))
+		Expect(envoyDeployment.InitContainers[2].Env).To(ContainElement(corev1.EnvVar{
+			Name:  "WAF_AUDIT_LOG_PATH",
+			Value: "/var/log/calico/gateway/envoy.log",
 		}))
 
 		Expect(envoyDeployment.Container).ToNot(BeNil())

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1132,6 +1132,12 @@ value:
 		}))
 
 		Expect(proxy.Spec.Telemetry.AccessLog.Settings).To(Equal(AccessLogSettings))
+
+		// WAF audit capture: the wasm component logs at info so Coraza "AuditLog:" lines
+		// reach Envoy's application log, while everything else stays at warn so the
+		// redirected log file is approximately just the audit lines.
+		Expect(proxy.Spec.Logging.Level).To(HaveKeyWithValue(envoyapi.LogComponentDefault, envoyapi.LogLevelWarn))
+		Expect(proxy.Spec.Logging.Level).To(HaveKeyWithValue(envoyapi.ProxyLogComponent("wasm"), envoyapi.LogLevelInfo))
 	})
 
 	It("should deploy waf-http-filter for Enterprise when using a custom proxy", func() {

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1138,6 +1138,12 @@ value:
 		// redirected log file is approximately just the audit lines.
 		Expect(proxy.Spec.Logging.Level).To(HaveKeyWithValue(envoyapi.LogComponentDefault, envoyapi.LogLevelWarn))
 		Expect(proxy.Spec.Logging.Level).To(HaveKeyWithValue(envoyapi.ProxyLogComponent("wasm"), envoyapi.LogLevelInfo))
+
+		// WAF audit capture: Envoy's application log is redirected to a file on the
+		// var-log-calico HostPath volume via --log-path (appended through ExtraArgs,
+		// which Envoy Gateway adds to the proxy args verbatim - each token a separate
+		// element). The l7-log-collector tails this file.
+		Expect(proxy.Spec.ExtraArgs).To(Equal([]string{"--log-path", "/var/log/calico/gateway/envoy.log"}))
 	})
 
 	It("should deploy waf-http-filter for Enterprise when using a custom proxy", func() {

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1105,7 +1105,7 @@ value:
 
 		Expect(envoyDeployment.InitContainers[1].Name).To(Equal("l7-log-collector"))
 		Expect(*envoyDeployment.InitContainers[1].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
-		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(HaveLen(3))
+		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(HaveLen(2))
 		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(ContainElements([]corev1.VolumeMount{
 			{
 				Name:      "access-logs",
@@ -1115,15 +1115,12 @@ value:
 				Name:      "felix-sync",
 				MountPath: "/var/run/felix",
 			},
-			{
-				Name:      "var-log-calico",
-				MountPath: "/var/log/calico",
-			},
 		}))
-		// WAF audit capture: the l7-log-collector tails the redirected Envoy app log.
+		// WAF audit capture: the l7-log-collector tails the redirected Envoy app log on
+		// the access-logs volume it already mounts.
 		Expect(envoyDeployment.InitContainers[1].Env).To(ContainElement(corev1.EnvVar{
 			Name:  "WAF_AUDIT_LOG_PATH",
-			Value: "/var/log/calico/gateway/envoy.log",
+			Value: "/access_logs/envoy.log",
 		}))
 
 		// logger gateway name and namespace are set from the k8s downward api pod metadata.
@@ -1152,7 +1149,7 @@ value:
 		// var-log-calico HostPath volume via --log-path (appended through ExtraArgs,
 		// which Envoy Gateway adds to the proxy args verbatim - each token a separate
 		// element). The l7-log-collector tails this file.
-		Expect(proxy.Spec.ExtraArgs).To(Equal([]string{"--log-path", "/var/log/calico/gateway/envoy.log"}))
+		Expect(proxy.Spec.ExtraArgs).To(Equal([]string{"--log-path", "/access_logs/envoy.log"}))
 	})
 
 	It("should deploy waf-http-filter for Enterprise when using a custom proxy", func() {
@@ -1261,7 +1258,7 @@ value:
 
 		Expect(envoyDeployment.InitContainers[2].Name).To(Equal("l7-log-collector"))
 		Expect(*envoyDeployment.InitContainers[2].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
-		Expect(envoyDeployment.InitContainers[2].VolumeMounts).To(HaveLen(3))
+		Expect(envoyDeployment.InitContainers[2].VolumeMounts).To(HaveLen(2))
 		Expect(envoyDeployment.InitContainers[2].VolumeMounts).To(ContainElements([]corev1.VolumeMount{
 			{
 				Name:      "access-logs",
@@ -1271,14 +1268,10 @@ value:
 				Name:      "felix-sync",
 				MountPath: "/var/run/felix",
 			},
-			{
-				Name:      "var-log-calico",
-				MountPath: "/var/log/calico",
-			},
 		}))
 		Expect(envoyDeployment.InitContainers[2].Env).To(ContainElement(corev1.EnvVar{
 			Name:  "WAF_AUDIT_LOG_PATH",
-			Value: "/var/log/calico/gateway/envoy.log",
+			Value: "/access_logs/envoy.log",
 		}))
 
 		Expect(envoyDeployment.Container).ToNot(BeNil())


### PR DESCRIPTION
## Description

New feature (Calico Enterprise only). Part of **EV-6650** (WAF observability), stacked on **op#4821** (WAF v3 render) — base branch `seth/applicationlayer-render-v3`.

This wires the Gateway API / `EnvoyProxy` render so the data-plane Envoy proxy captures the Coraza WAF filter's audit decision log (the "B-log capture" path):

- **Tune proxy log levels** — set `EnvoyProxy.Spec.Logging.Level` to `{default: warn, wasm: info}` so the wasm component's `AuditLog:` lines (emitted via `proxywasm.LogInfo`) surface in Envoy's application log while the rest stays quiet. `wasm` is not an Envoy Gateway const, but EG passes arbitrary component keys through to Envoy's `--component-log-level`, and Envoy recognises `wasm`.
- **Redirect the application log to a file** — append `--log-path /access_logs/envoy.log` via `EnvoyProxy.Spec.ExtraArgs` (EG appends these to the proxy command line verbatim). `ExtraArgs` is used rather than an `EnvoyDeployment.Patch` on the container args, because a strategic/JSON-merge patch *replaces* the whole args list and would clobber EG's generated args.
- **Point the l7-log-collector at it** — set `WAF_AUDIT_LOG_PATH=/access_logs/envoy.log` on the `l7-log-collector` init container. The file lives on the existing `access-logs` emptyDir, already mounted in both the envoy container (which writes it) and the l7-log-collector (which reads it), so no new volume or mount is needed.

The l7-log-collector (calico-private, separate PR) tails this file and forwards WAF decision records via the existing `PolicySync.ReportWAF` gRPC to Felix → the durable `tigera_secure_ee_waf` index.

**Components affected:** `pkg/render/gatewayapi` (`envoyProxyConfig`).

**Testing:**
- Unit tests (TDD) extend the Enterprise `EnvoyProxy` render assertions in `gateway_api_test.go`. `go build ./...` and `go test ./pkg/render/...` pass; `gofmt`/`go vet` clean.
- **Cluster-validated** on a live Envoy Gateway proxy (Calico Enterprise): a SQLi against a Block-mode WAFPolicy returns `403`, and the Coraza `AuditLog:{...}` JSON (with the block decision + request context) is captured at `[info][wasm]` in `/access_logs/envoy.log` on the proxy pod. This validation also caught and fixed a path bug: the envoy container does not mount `var-log-calico`, and Envoy does not create the `--log-path` parent directory, so the original `/var/log/calico/gateway/envoy.log` could not be opened — the audit log is now written to the already-shared `access-logs` emptyDir.

**Issues:** EV-6650.

## Release Note

```release-note
The Calico Enterprise Gateway data-plane Envoy proxy now captures the WAF (Coraza) audit decision log to a file for collection by the l7-log-collector.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files` — n/a (no API change)
- [ ] If changing versions, run `make gen-versions` — n/a
